### PR TITLE
feat: implement exams CRUD with API integration

### DIFF
--- a/app/components/MyCourse/[id]/ExamCard.tsx
+++ b/app/components/MyCourse/[id]/ExamCard.tsx
@@ -35,7 +35,7 @@ import { z } from "zod";
 
 export type ExamCardProps = {
   exam: {
-    id: number;
+    id: string;
     title: string;
     description?: string;
     date: Date;

--- a/app/components/MyCourse/[id]/ExamCard.tsx
+++ b/app/components/MyCourse/[id]/ExamCard.tsx
@@ -1,4 +1,5 @@
 import type { Exam } from "../../types/exam";
+import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import {
@@ -32,7 +33,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { CalendarIcon, Pencil } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
+import { examFormSchema } from "../createExam";
 
 type ExamCardProps = {
   exam: Exam;
@@ -51,20 +52,30 @@ type ExamCardProps = {
   ) => Promise<{ message: string } | null>;
 };
 
-// Validation schema for all form inputs
-const formSchema = z.object({
-  title: z.string().min(1, { message: "Title is required." }),
-  description: z.string().optional(),
-  date: z.date({ required_error: "Date is required." }),
-});
-
 export const ExamCard = (props: ExamCardProps) => {
   const { title, description, date } = props.exam;
   const { updateExam, deleteExam, onUpdateExams, exam, examList, courseId } = props;
 
   const daysLeft = getDaysLeft(date);
   const [isSheetOpen, setIsSheetOpen] = useState<boolean>(false);
+  const [isFormValid, setIsFormValid] = useState(false);
+
   const { toast } = useToast();
+
+  const form = useForm({
+    resolver: zodResolver(examFormSchema),
+    defaultValues: {
+      title: title,
+      description: description || "",
+      date: new Date(date),
+    }
+  });
+
+  const { formState } = form;
+
+  useEffect(() => {
+    setIsFormValid(formState.isValid);
+  }, [formState.isValid]);
 
   // Handle exam update
   const onSubmit = async (data: any) => {
@@ -113,15 +124,6 @@ export const ExamCard = (props: ExamCardProps) => {
 
   };
 
-  const form = useForm({
-    resolver: zodResolver(formSchema),
-    defaultValues: {
-      title: title,
-      description: description || "",
-      date: new Date(date),
-    },
-  });
-
   return (
     <div className="cursor-pointer transition-all p-5 bg-white bg-opacity-25 text-white outfit-regular rounded-lg border-2 border-white flex flex-col items-start gap-3 w-full max-w-xs min-w-xs lg:min-w-[48.5%] lg:max-w-[48.5%]">
       <div className="flex items-center justify-between w-full">
@@ -160,10 +162,10 @@ export const ExamCard = (props: ExamCardProps) => {
                   name="title"
                   render={({ field }: { field: any }) => (
                     <FormItem className="w-full">
-                      <FormLabel>Title</FormLabel>
+                      <FormLabel>Titre</FormLabel>
                       <FormControl>
                         <Input
-                          placeholder="Type your title here"
+                          placeholder="Quel est le titre de l'examen ?"
                           className="w-full"
                           {...field}
                         />
@@ -182,7 +184,7 @@ export const ExamCard = (props: ExamCardProps) => {
                       <FormLabel>Description</FormLabel>
                       <FormControl>
                         <Textarea
-                          placeholder="Type your description here."
+                          placeholder="Décrivez l'examen en quelques mots (optionnel)"
                           className="w-full"
                           {...field}
                         />
@@ -257,7 +259,7 @@ export const ExamCard = (props: ExamCardProps) => {
                     </Button>
 
                     {/* Modifier button */}
-                    <Button className="w-full" type="submit">
+                    <Button className="w-full" type="submit" disabled={!isFormValid}>
                         Modifier
                     </Button>
                   </div>

--- a/app/components/MyCourse/[id]/ExamCard.tsx
+++ b/app/components/MyCourse/[id]/ExamCard.tsx
@@ -43,6 +43,7 @@ type Exam = {
 type ExamCardProps = {
   exam: Exam;
   examList: any[];
+  courseId: string;
   onUpdateExams: (newExamList: Exam[]) => void;
   updateExam: (
     examId: string,
@@ -51,7 +52,8 @@ type ExamCardProps = {
     date: Date
   ) => Promise<{ message: string } | null>;
   deleteExam: (
-    examId: string
+    examId: string,
+    courseId: string
   ) => Promise<{ message: string } | null>;
 };
 
@@ -64,7 +66,7 @@ const formSchema = z.object({
 
 export const ExamCard = (props: ExamCardProps) => {
   const { title, description, date } = props.exam;
-  const { updateExam, deleteExam, onUpdateExams, exam, examList } = props;
+  const { updateExam, deleteExam, onUpdateExams, exam, examList, courseId } = props;
 
   const daysLeft = getDaysLeft(date);
   const [isSheetOpen, setIsSheetOpen] = useState<boolean>(false);
@@ -106,7 +108,7 @@ export const ExamCard = (props: ExamCardProps) => {
   // Handle exam deletion
   const handleDelete = async (examId: string) => {
 
-    const deletionResponse = await deleteExam(examId);
+    const deletionResponse = await deleteExam(examId, courseId);
     const updatedList = examList.filter((exam) => exam._id !== examId);
 
     if (deletionResponse) {

--- a/app/components/MyCourse/[id]/ExamCard.tsx
+++ b/app/components/MyCourse/[id]/ExamCard.tsx
@@ -1,3 +1,4 @@
+import type { Exam } from "../../types/exam";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import {
@@ -33,18 +34,11 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-type Exam = {
-  _id: string;
-  title: string;
-  description?: string;
-  date: Date;
-};
-
 type ExamCardProps = {
   exam: Exam;
   examList: any[];
   courseId: string;
-  onUpdateExams: (newExamList: Exam[]) => void;
+  onUpdateExams: (updatedExam: Exam | null, deletedExamId?: string) => void;
   updateExam: (
     examId: string,
     title: string,
@@ -82,19 +76,16 @@ export const ExamCard = (props: ExamCardProps) => {
       date: new Date(data.date),
     };
 
-    // Update the exam list
-    const updatedExamsList = examList.map((exam) =>
-      exam._id === props.exam._id ? updatedExam : exam
-    );
-
-    // Update the exams list in the parent component
-    onUpdateExams(updatedExamsList);
     const updateResponse = await updateExam(
       exam._id,
       updatedExam.title,
       updatedExam.description,
       updatedExam.date
     );
+
+    if (updateResponse) {
+      onUpdateExams(updatedExam);
+    }
 
     setIsSheetOpen(false);
 
@@ -109,10 +100,9 @@ export const ExamCard = (props: ExamCardProps) => {
   const handleDelete = async (examId: string) => {
 
     const deletionResponse = await deleteExam(examId, courseId);
-    const updatedList = examList.filter((exam) => exam._id !== examId);
 
     if (deletionResponse) {
-      onUpdateExams(updatedList);
+      onUpdateExams(null, examId);
     }
 
     setIsSheetOpen(false);

--- a/app/components/MyCourse/createExam.tsx
+++ b/app/components/MyCourse/createExam.tsx
@@ -42,11 +42,13 @@ const formSchema = z.object({
 });
 
 export type createExamProps = {
+  courseId: string;
   examList: any[];
-  ctaAddExam: (exam: any) => void;
+  onUpdateExams: (newExamList: any[]) => void;
+  createExam: (courseId: string, title: string, description: string, date: Date) => Promise<{ message: string } | null>;
 };
 
-export const CreateExam = ({ examList, ctaAddExam }: createExamProps) => {
+export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: createExamProps) => {
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
   const { toast } = useToast();
 
@@ -69,23 +71,27 @@ export const CreateExam = ({ examList, ctaAddExam }: createExamProps) => {
       });
       return;
     }
-    const maxId =
-      examList.length > 0 ? Math.max(...examList.map((exam) => exam.id)) : -1;
+
     const newExam = {
-      id: maxId + 1,
       title: data.title,
       description: data.description,
       date: new Date(data.date),
     };
-    const sortedList = [...examList, newExam].sort((a: any, b: any) => {
-      return a.date.getTime() - b.date.getTime();
-    });
 
-    ctaAddExam(sortedList);
+    const updatedList = [...examList, newExam];
+
+    const creationResponse = await createExam(courseId, newExam.title, newExam.description, newExam.date);
+
+    if (creationResponse) {
+      onUpdateExams(updatedList);
+    }
+
+    // Close the modal and reset form values
     setIsDialogOpen(false);
     form.reset();
+
     toast({
-      title: "Nouvel examen ajouté",
+      title: creationResponse?.message || "",
       description: "Pour la date " + newExam.date.toLocaleDateString(),
     });
   };

--- a/app/components/MyCourse/createExam.tsx
+++ b/app/components/MyCourse/createExam.tsx
@@ -33,6 +33,7 @@ import { CalendarIcon, Plus } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import type { Exam } from "../types/exam";
 
 // Validation schema for all form inputs
 const formSchema = z.object({
@@ -44,7 +45,7 @@ const formSchema = z.object({
 export type createExamProps = {
   courseId: string;
   examList: any[];
-  onUpdateExams: (newExamList: any[]) => void;
+  onUpdateExams: (updatedExam: Exam | null, deletedExamId?: string) => void;
   createExam: (courseId: string, title: string, description: string, date: Date) => Promise<{ id: string, message: string } | null>;
 };
 
@@ -80,8 +81,6 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
       date: new Date(data.date),
     };
 
-    const updatedList = [...examList, newExam];
-
     const creationResponse = await createExam(
       courseId,
       newExam.title,
@@ -91,7 +90,7 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
 
     if (creationResponse) {
       newExam._id = creationResponse.id;
-      onUpdateExams(updatedList);
+      onUpdateExams(newExam);
     }
 
     // Close the modal and reset form values

--- a/app/components/MyCourse/createExam.tsx
+++ b/app/components/MyCourse/createExam.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import {
@@ -37,9 +38,13 @@ import type { Exam } from "../types/exam";
 
 // Validation schema for all form inputs
 const formSchema = z.object({
-  title: z.string().min(1, { message: "Title is required." }),
-  description: z.string().optional(),
-  date: z.date({ required_error: "Date is required." }),
+  title: z.string()
+    .min(1, { message: "Le titre est requis." })
+    .max(50, { message: "Le titre peut avoir un maximum de 50 caractères." }),
+  description: z.string()
+    .max(200, {message: "La description peut avoir un maximum de 200 caractères."})
+    .optional(),
+  date: z.date({ required_error: "La date est requise." }),
 });
 
 export type createExamProps = {
@@ -51,6 +56,8 @@ export type createExamProps = {
 
 export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: createExamProps) => {
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+  const [isFormValid, setIsFormValid] = useState(false);
+
   const { toast } = useToast();
 
   // Initialize the form using react-hook-form and zod
@@ -61,7 +68,14 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
       description: "",
       date: new Date(),
     },
+    mode: 'onChange'
   });
+
+  const { formState } = form;
+
+  useEffect(() => {
+    setIsFormValid(formState.isValid);
+  }, [formState.isValid]);
 
   // Handle exam creation
   const onSubmit = async (data: any) => {
@@ -214,7 +228,7 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
                 >
                   Cancel
                 </Button>
-                <Button type="submit">Ajouter</Button>
+                <Button type="submit" disabled={!isFormValid}>Ajouter</Button>
               </div>
             </DialogFooter>
           </form>

--- a/app/components/MyCourse/createExam.tsx
+++ b/app/components/MyCourse/createExam.tsx
@@ -62,6 +62,7 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
     },
   });
 
+  // Handle exam creation
   const onSubmit = async (data: any) => {
     const daysLeft = getDaysLeft(data.date);
     if (daysLeft <= 0) {
@@ -80,7 +81,12 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
 
     const updatedList = [...examList, newExam];
 
-    const creationResponse = await createExam(courseId, newExam.title, newExam.description, newExam.date);
+    const creationResponse = await createExam(
+      courseId,
+      newExam.title,
+      newExam.description,
+      newExam.date
+    );
 
     if (creationResponse) {
       onUpdateExams(updatedList);
@@ -90,10 +96,12 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
     setIsDialogOpen(false);
     form.reset();
 
+    // Toast with server's response message
     toast({
       title: creationResponse?.message || "",
       description: "Pour la date " + newExam.date.toLocaleDateString(),
     });
+
   };
 
   return (

--- a/app/components/MyCourse/createExam.tsx
+++ b/app/components/MyCourse/createExam.tsx
@@ -37,7 +37,7 @@ import { z } from "zod";
 import type { Exam } from "../types/exam";
 
 // Validation schema for all form inputs
-const formSchema = z.object({
+export const examFormSchema = z.object({
   title: z.string()
     .min(1, { message: "Le titre est requis." })
     .max(50, { message: "Le titre peut avoir un maximum de 50 caractères." }),
@@ -62,7 +62,7 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
 
   // Initialize the form using react-hook-form and zod
   const form = useForm({
-    resolver: zodResolver(formSchema),
+    resolver: zodResolver(examFormSchema),
     defaultValues: {
       title: "",
       description: "",

--- a/app/components/MyCourse/createExam.tsx
+++ b/app/components/MyCourse/createExam.tsx
@@ -136,7 +136,7 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
         <DialogHeader>
           <DialogTitle>Ajouter un examen</DialogTitle>
           <DialogDescription className="text-white text-opacity-50">
-            Ajoutes un examen pour connaître le temps qu'il te restes pour
+            Ajoute un examen pour connaître le temps qu'il te reste pour
             apprendre ce cours.
           </DialogDescription>
         </DialogHeader>
@@ -226,7 +226,7 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
                   className="mr-auto hover:bg-white hover:bg-opacity-10 transition-all"
                   onClick={() => setIsDialogOpen(false)}
                 >
-                  Cancel
+                  Annuler
                 </Button>
                 <Button type="submit" disabled={!isFormValid}>Ajouter</Button>
               </div>

--- a/app/components/MyCourse/createExam.tsx
+++ b/app/components/MyCourse/createExam.tsx
@@ -45,7 +45,7 @@ export type createExamProps = {
   courseId: string;
   examList: any[];
   onUpdateExams: (newExamList: any[]) => void;
-  createExam: (courseId: string, title: string, description: string, date: Date) => Promise<{ message: string } | null>;
+  createExam: (courseId: string, title: string, description: string, date: Date) => Promise<{ id: string, message: string } | null>;
 };
 
 export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: createExamProps) => {
@@ -74,6 +74,7 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
     }
 
     const newExam = {
+      _id: "",
       title: data.title,
       description: data.description,
       date: new Date(data.date),
@@ -89,6 +90,7 @@ export const CreateExam = ({ courseId, examList, onUpdateExams, createExam }: cr
     );
 
     if (creationResponse) {
+      newExam._id = creationResponse.id;
       onUpdateExams(updatedList);
     }
 

--- a/app/components/MyCourse/createExam.tsx
+++ b/app/components/MyCourse/createExam.tsx
@@ -47,7 +47,7 @@ export const examFormSchema = z.object({
   date: z.date({ required_error: "La date est requise." }),
 });
 
-export type createExamProps = {
+type createExamProps = {
   courseId: string;
   examList: any[];
   onUpdateExams: (updatedExam: Exam | null, deletedExamId?: string) => void;

--- a/app/components/types/exam.d.ts
+++ b/app/components/types/exam.d.ts
@@ -1,0 +1,6 @@
+export type Exam = {
+    _id: string;
+    title: string;
+    description?: string;
+    date: Date;
+};

--- a/app/hooks/useCourse.ts
+++ b/app/hooks/useCourse.ts
@@ -70,11 +70,13 @@ export function useCourse(courseService: CourseService) {
         title: string,
         description: string,
         date: Date
-    ) : Promise<{ message: string } | null> => {
+    ) : Promise<{ id: string, message: string } | null> => {
         try {
             const response = await courseService.createExam(courseId, title, description, date);
-            return response?.message ? { message: response.message } : null;
+            return response ? { id: response.id, message: response.message } : null;
         } catch (error) {
+            const response = await courseService.createExam(courseId, title, description, date);
+            return response ? { message: response.message, id: response.id } : null;
             console.error("Error creating exam: ", error);
             setError(`Failed to create an exam for the course ${courseId}. Please try again.`);
             return null;

--- a/app/hooks/useCourse.ts
+++ b/app/hooks/useCourse.ts
@@ -125,9 +125,9 @@ export function useCourse(courseService: CourseService) {
         }
     }
 
-    const deleteExamById = async (examId: string) => {
+    const deleteExamById = async (examId: string, courseId: string) => {
         try {
-            const response = await courseService.deleteExamById(examId);
+            const response = await courseService.deleteExamById(examId, courseId);
             return response;
         } catch (error) {
             console.error(`Error deleting exam with id ${examId}: `, error);

--- a/app/hooks/useCourse.ts
+++ b/app/hooks/useCourse.ts
@@ -65,7 +65,12 @@ export function useCourse(courseService: CourseService) {
         }
     }
 
-    const createExam = async (courseId: string, title: string, description: string, date: Date ): Promise<{ message: string } | null> => {
+    const createExam = async (
+        courseId: string,
+        title: string,
+        description: string,
+        date: Date
+    ) : Promise<{ message: string } | null> => {
         try {
             const response = await courseService.createExam(courseId, title, description, date);
             return response?.message ? { message: response.message } : null;
@@ -104,6 +109,34 @@ export function useCourse(courseService: CourseService) {
         }
     }
 
+    const updateExamById = async (
+        examId: string,
+        title: string,
+        description: string,
+        date: Date
+    ) : Promise<{ message: string } | null > => {
+        try {
+            const response = await courseService.updateExamById(examId, title, description, date);
+            return response;
+        } catch (error) {
+            console.error(`Error updating exam with id ${examId}: `, error);
+            setError(`Failed to update exam. Please try again.`);
+            return null;
+        }
+    }
+
+    const deleteExamById = async (examId: string) => {
+        try {
+            const response = await courseService.deleteExamById(examId);
+            return response;
+        } catch (error) {
+            console.error(`Error deleting exam with id ${examId}: `, error);
+            setError(`Failed to delete exam. Please try again.`);
+            return null;
+        }
+    }
+
     return { courseId, isCreating, courseData, examsData, courseError,
-        createCourse, loadCourse, addQuizToCourse, createExam, getExams };
+        createCourse, loadCourse, addQuizToCourse, createExam, getExams,
+        updateExamById, deleteExamById };
 }

--- a/app/hooks/useCourse.ts
+++ b/app/hooks/useCourse.ts
@@ -80,14 +80,19 @@ export function useCourse(courseService: CourseService) {
         try {
             const response = await Promise.all(
                 courseExamsIds.map(async (examId) => {
-                    const exam = await courseService.getExamById(examId);
-                    return exam.item;
+                    try {
+                        const exam = await courseService.getExamById(examId);
+                        return exam.item;
+                    } catch (error) {
+                        console.error(`Error fetching exam with id ${examId}:`, error)
+                        return null;
+                    }
                 })
             );
 
-            const examsData = response.sort((a, b) => {
-                return new Date(a.date).getTime() - new Date(b.date).getTime();
-            });
+            const examsData = response
+                .filter((exam) => exam !== null)
+                .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
             setExamsData(examsData);
 

--- a/app/myCourses/[id]/page.tsx
+++ b/app/myCourses/[id]/page.tsx
@@ -49,7 +49,8 @@ export default function myCoursesPage() {
   const [quizId, setQuizId] = useState("");
 
   const courseService = useCourseService();
-  const { courseData, examsData, loadCourse, createExam, getExams } = useCourse(courseService);
+  const { courseData, examsData, loadCourse, createExam, getExams,
+      updateExamById, deleteExamById } = useCourse(courseService);
 
   const quizService = useQuizService();
   const insightsService = useInsightsService();
@@ -280,8 +281,10 @@ export default function myCoursesPage() {
                   <ExamCard
                     exam={exam}
                     key={index}
-                    ctaSetExam={handleUpdateExams} // TODO: handle update via api call
-                    examsList={updatedExams}
+                    examList={examsData}
+                    onUpdateExams={handleUpdateExams}
+                    updateExam={updateExamById}
+                    deleteExam={deleteExamById}
                   />
                 ))}
               </div>

--- a/app/myCourses/[id]/page.tsx
+++ b/app/myCourses/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Exam } from "@/app/components/types/exam";
 import { ExamCard } from "@/app/components/MyCourse/[id]/ExamCard";
 import { FileSection } from "@/app/components/MyCourse/[id]/FileSection";
 import {
@@ -33,8 +34,6 @@ import {
 
 // Temporary test data for the course
 import course from "@/app/json/testData/course.json";
-
-// Temporary test data for the quiz
 
 export default function myCoursesPage() {
   const params = useParams();
@@ -97,9 +96,26 @@ export default function myCoursesPage() {
 
   const [updatedExams, setUpdatedExams] = useState<any[]>([]);
 
-  const handleUpdateExams = (newExamList : any[]) => {
-      setUpdatedExams(newExamList);
-  }
+  const handleUpdateExams = (updatedExam: Exam | null, deletedExamId?: string) => {
+    if (deletedExamId) {
+      // Handle deletion: Remove the deleted exam from the list
+      setUpdatedExams((prevExams) => prevExams.filter((exam) => exam._id !== deletedExamId));
+    } else if (updatedExam) {
+      // Handle update / add
+      setUpdatedExams((prevExams) => {
+        const index = prevExams.findIndex((exam) => exam._id === updatedExam._id);
+        if (index !== -1) {
+          // Update existing exam
+          return prevExams.map((exam) =>
+            exam._id === updatedExam._id ? updatedExam : exam
+          );
+        } else {
+          // Add new exam if it doesn't exist
+          return [...prevExams, updatedExam];
+        }
+      });
+    }
+  };
 
   const updateFile = (updatedFiles: any[]) => {
     setResumeFiles(updatedFiles);

--- a/app/myCourses/[id]/page.tsx
+++ b/app/myCourses/[id]/page.tsx
@@ -281,6 +281,7 @@ export default function myCoursesPage() {
                   <ExamCard
                     exam={exam}
                     key={index}
+                    courseId={courseId}
                     examList={examsData}
                     onUpdateExams={handleUpdateExams}
                     updateExam={updateExamById}

--- a/app/myCourses/[id]/page.tsx
+++ b/app/myCourses/[id]/page.tsx
@@ -49,7 +49,7 @@ export default function myCoursesPage() {
   const [quizId, setQuizId] = useState("");
 
   const courseService = useCourseService();
-  const { courseData, loadCourse } = useCourse(courseService);
+  const { courseData, examsData, loadCourse, createExam, getExams } = useCourse(courseService);
 
   const quizService = useQuizService();
   const insightsService = useInsightsService();
@@ -66,7 +66,16 @@ export default function myCoursesPage() {
 
   useEffect(() => {
     fetchQuiz();
+    if (courseData?.exams) {
+      getExams(courseData.exams);
+    }
   }, [courseData, isQuestionsVisible]);
+
+  useEffect(() => {
+    if (examsData) {
+      setUpdatedExams(examsData);
+    }
+  }, [examsData]);
 
   // For now we handle only the first quiz of the course
   const fetchQuiz = async () => {
@@ -84,7 +93,12 @@ export default function myCoursesPage() {
     e.preventDefault();
     router.push("/generator");
   };
-  const [exams, setExams] = useState<any[]>([]);
+
+  const [updatedExams, setUpdatedExams] = useState<any[]>([]);
+
+  const handleUpdateExams = (newExamList : any[]) => {
+      setUpdatedExams(newExamList);
+  }
 
   const updateFile = (updatedFiles: any[]) => {
     setResumeFiles(updatedFiles);
@@ -235,13 +249,13 @@ export default function myCoursesPage() {
                     Examens Prévus
                   </p>
                   <p className="text-xs lg:text-sm text-white text-opacity-75 outfit-regular mr-auto w-full">
-                    Tu {exams.length === 0 && "n'"}as{" "}
+                    Tu {updatedExams.length === 0 && "n'"}as{" "}
                     <span className="text-accent text-opacity-75">
-                      {exams.length === 0 ? "aucun" : exams.length}
+                      {updatedExams.length === 0 ? "aucun" : updatedExams.length}
                     </span>{" "}
-                    {exams.length === 0
+                    {updatedExams.length === 0
                       ? "examen prévu"
-                      : exams.length > 1
+                      : updatedExams.length > 1
                       ? "examens prévus"
                       : "examen prévu"}{" "}
                     pour ce cours.
@@ -251,18 +265,23 @@ export default function myCoursesPage() {
                 <div className="mt-2 lg:mt-0 ml-auto w-full lg:w-auto">
                   {" "}
                   {/* Add ml-auto here */}
-                  <CreateExam examList={exams} ctaAddExam={setExams} />
+                  <CreateExam
+                    courseId={courseId}
+                    examList={examsData}
+                    onUpdateExams={handleUpdateExams}
+                    createExam={createExam}
+                  />
                 </div>
               </div>
 
               {/* Cards */}
               <div className="flex flex-col lg:flex-row lg:flex-wrap items-center justify-between gap-4 w-full">
-                {exams.map((exam, index) => (
+                {updatedExams?.map((exam, index) => (
                   <ExamCard
                     exam={exam}
                     key={index}
-                    ctaSetExam={setExams}
-                    examsList={exams}
+                    ctaSetExam={handleUpdateExams} // TODO: handle update via api call
+                    examsList={updatedExams}
                   />
                 ))}
               </div>

--- a/app/myCourses/[id]/page.tsx
+++ b/app/myCourses/[id]/page.tsx
@@ -282,7 +282,7 @@ export default function myCoursesPage() {
                     exam={exam}
                     key={index}
                     courseId={courseId}
-                    examList={examsData}
+                    examList={updatedExams}
                     onUpdateExams={handleUpdateExams}
                     updateExam={updateExamById}
                     deleteExam={deleteExamById}

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -13,7 +13,7 @@ const TOAST_REMOVE_DELAY = 1000000
 
 type ToasterToast = ToastProps & {
   id: string
-  title?: React.ReactNode
+  title?: string
   description?: React.ReactNode
   action?: ToastActionElement
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,8 +5,9 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function getDaysLeft(date: Date) {
+export function getDaysLeft(date: Date | string) {
   const today = new Date();
-  const timeDiff = date.getTime() - today.getTime();
+  const targetDate = new Date(date);
+  const timeDiff = targetDate.getTime() - today.getTime();
   return Math.ceil(timeDiff / (1000 * 3600 * 24));
 }

--- a/services/course.ts
+++ b/services/course.ts
@@ -5,7 +5,7 @@ export interface CourseService {
     createCourse: (title: string, subject: string, level: string) => Promise<any>;
     getCourseById: (courseId: string) => Promise<any>;
     addQuizToCourse: (courseId: string, quizId: string) => Promise<any>;
-    createExam: (courseId: string, title: string, description: string, date: Date) => Promise<{ message: string } | null>;
+    createExam: (courseId: string, title: string, description: string, date: Date) => Promise<{ id: string, message: string } | null>;
     getExamById: (examId: string) => Promise<any>;
     deleteExamById: (examId: string, courseId: string ) => Promise<{ message: string } | null>;
     updateExamById: (examId: string, title: string, description: string, date: Date) => Promise<{ message: string } | null>;
@@ -58,7 +58,7 @@ export function useCourseService() {
         title: string,
         description: string,
         date: Date
-    ): Promise<{ message: string } | null> => {
+    ): Promise<{ id: string, message: string } | null> => {
         try {
             const response = await axios.post(`${apiUrl}/courses/${courseId}/exams`,
                 { title, description, date },

--- a/services/course.ts
+++ b/services/course.ts
@@ -5,6 +5,8 @@ export interface CourseService {
     createCourse: (title: string, subject: string, level: string) => Promise<any>;
     getCourseById: (courseId: string) => Promise<any>;
     addQuizToCourse: (courseId: string, quizId: string) => Promise<any>;
+    createExam: (courseId: string, title: string, description: string, date: Date) => Promise<{ message: string } | null>;
+    getExamById: (examId: string) => Promise<any>;
 }
 
 export function useCourseService() {
@@ -46,7 +48,37 @@ export function useCourseService() {
         }
     }
 
-    return { createCourse, getCourseById, addQuizToCourse };
+    const createExam = async (
+        courseId: string,
+        title: string,
+        description: string,
+        date: Date
+    ): Promise<{ message: string } | null> => {
+        try {
+            const response = await axios.post(`${apiUrl}/courses/${courseId}/exams`,
+                { title, description, date},
+                { withCredentials: true }
+            );
+            return response.data;
+        } catch (error) {
+            console.error(`An error ocurred creating an exam for the course ${courseId}`, error);
+            return null;
+        }
+    }
+
+    const getExamById = async ( examId: string ) => {
+        try {
+            const response = await axios.get(`${apiUrl}/exams/${examId}`,
+                { withCredentials: true }
+            );
+            return response.data;
+        } catch (error) {
+            console.error(`An error ocurred getting exam ${examId}`, error);
+        }
+    }
+
+
+    return { createCourse, getCourseById, addQuizToCourse, createExam, getExamById };
 }
 
 

--- a/services/course.ts
+++ b/services/course.ts
@@ -7,12 +7,15 @@ export interface CourseService {
     addQuizToCourse: (courseId: string, quizId: string) => Promise<any>;
     createExam: (courseId: string, title: string, description: string, date: Date) => Promise<{ message: string } | null>;
     getExamById: (examId: string) => Promise<any>;
+    deleteExamById: (examId: string,) => Promise<{ message: string } | null>;
+    updateExamById: (examId: string, title: string, description: string, date: Date) => Promise<{ message: string } | null>;
 }
 
 export function useCourseService() {
 
     const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
+    // Course \\
     const createCourse = async (title: string, subject: string, level: string) => {
         try {
             const response = await axios.post(`${apiUrl}/courses/create`,
@@ -36,6 +39,7 @@ export function useCourseService() {
         }
     }
 
+    // Course's Quizs \\
     const addQuizToCourse = async (courseId: string, quizId: string) => {
         try {
             const response = await axios.post(`${apiUrl}/courses/${courseId}/addQuiz`,
@@ -48,6 +52,7 @@ export function useCourseService() {
         }
     }
 
+    // Course's Exams \\
     const createExam = async (
         courseId: string,
         title: string,
@@ -56,7 +61,7 @@ export function useCourseService() {
     ): Promise<{ message: string } | null> => {
         try {
             const response = await axios.post(`${apiUrl}/courses/${courseId}/exams`,
-                { title, description, date},
+                { title, description, date },
                 { withCredentials: true }
             );
             return response.data;
@@ -77,8 +82,40 @@ export function useCourseService() {
         }
     }
 
+    const updateExamById = async (
+        examId: string,
+        title: string,
+        description: string,
+        date: Date
+    ) : Promise<{ message: string } | null > => {
+        try {
+            const response = await axios.put(`${apiUrl}/exams/${examId}`,
+                { title, description, date },
+                { withCredentials: true }
+            );
+            return response.data;
+        } catch (error) {
+            console.error(`An error ocurred updating exam ${examId}`, error);
+            return null;
+        }
+    }
 
-    return { createCourse, getCourseById, addQuizToCourse, createExam, getExamById };
+    const deleteExamById = async ( examId: string ) :
+        Promise<{ message: string } | null > =>
+    {
+        try {
+            const response = await axios.delete(`${apiUrl}/exams/${examId}`,
+                { withCredentials: true }
+            );
+            return response.data;
+        } catch (error) {
+            console.error(`An error ocurred deleting exam ${examId}`, error);
+            return null;
+        }
+    }
+
+    return { createCourse, getCourseById, addQuizToCourse, createExam,
+        getExamById, updateExamById, deleteExamById };
 }
 
 

--- a/services/course.ts
+++ b/services/course.ts
@@ -7,7 +7,7 @@ export interface CourseService {
     addQuizToCourse: (courseId: string, quizId: string) => Promise<any>;
     createExam: (courseId: string, title: string, description: string, date: Date) => Promise<{ message: string } | null>;
     getExamById: (examId: string) => Promise<any>;
-    deleteExamById: (examId: string,) => Promise<{ message: string } | null>;
+    deleteExamById: (examId: string, courseId: string ) => Promise<{ message: string } | null>;
     updateExamById: (examId: string, title: string, description: string, date: Date) => Promise<{ message: string } | null>;
 }
 
@@ -100,11 +100,11 @@ export function useCourseService() {
         }
     }
 
-    const deleteExamById = async ( examId: string ) :
+    const deleteExamById = async ( examId: string, courseId: string ) :
         Promise<{ message: string } | null > =>
     {
         try {
-            const response = await axios.delete(`${apiUrl}/exams/${examId}`,
+            const response = await axios.delete(`${apiUrl}/exams/${examId}/${courseId}`,
                 { withCredentials: true }
             );
             return response.data;


### PR DESCRIPTION
**Changes**:

- Add exam-related functions to the course service
- Implement full exams CRUD functionality on the course page using the new API endpoints
- Handle client-side state updates to avoid page refreshes after requests
- Disable submit buttons until form is valid.
- Display server messages in toast notifications
- Rename existing prop functions for improved consistency and readability
- Fixed some typos & translated some words to french