### PR TITLE
feat: generate and associate summary sheets on generation page

### DIFF
--- a/app/(dashboard)/generate/page.tsx
+++ b/app/(dashboard)/generate/page.tsx
@@ -13,8 +13,8 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { useCourse, useQuiz } from "@/hooks";
-import { useCourseService, useQuizService } from "@/services";
+import { useCourse, useQuiz, useSheet } from "@/hooks";
+import { useCourseService, useQuizService, useSummarySheetService, useBlobService } from "@/services";
 import { zodResolver } from "@hookform/resolvers/zod";
 import clsx from "clsx";
 import { CircleX, CloudUpload, FileText, WandSparkles, Sparkles } from "lucide-react";
@@ -80,8 +80,12 @@ export default function Generate() {
 
   // Course creation
   const courseService = useCourseService();
-  const { courseId, isCreating, courseError, createCourse, addQuizToCourse } =
-    useCourse(courseService);
+  const { courseId, isCreating, courseError, createCourse,
+    addQuizToCourse,addSheetToCourse } = useCourse(courseService);
+
+  const summarySheetsService = useSummarySheetService();
+  const blobService = useBlobService();
+  const { sheetId, generateSheet } = useSheet(summarySheetsService, blobService);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files || []);
@@ -135,22 +139,41 @@ export default function Generate() {
   const handleGenerate = async (formFields: GeneratorForm) => {
     if (recognizedTexts.length > 0) {
       setGenerationLaunched(true);
-      const generation = await generateQuiz(recognizedTexts);
 
-      if (generation?.success) {
-        const courseId = await createCourse(formFields);
-        await addQuizToCourse(courseId, generation.newQuizId);
-        // Each 1 second, call incrementGenerationStep until generationStep is 4
-        const interval = setInterval(() => {
-          incrementGenerationStep();
-          if (generationStep === 4) {
-            clearInterval(interval);
-          }
-        }, 1000);
-      } else {
-        // TODO: display message here once we implement toasts.
-        console.error("Failed to generate quiz, aborted course creation.");
+      const [quizGeneration, sheetGeneration] = await Promise.all([
+        generateQuiz(recognizedTexts),
+        generateSheet(recognizedTexts)
+      ]);
+
+      if (!quizGeneration?.success && !sheetGeneration?.success) {
+        // TODO: display message in a toast.
+        console.error("Failed to generate both quiz and summary sheet.")
+        return;
       }
+
+      let courseId = await createCourse(formFields);
+
+      if (quizGeneration?.success) {
+        await addQuizToCourse(courseId, quizGeneration.newQuizId);
+      } else {
+        // TODO: display message in a toast.
+        console.error("Failed to generate quiz.");
+      }
+
+      if (sheetGeneration?.success) {
+        await addSheetToCourse(courseId, sheetGeneration.newSheetId)
+      } else {
+        // TODO: display message in a toast.
+        console.error("Failed to generate summary sheet");
+      }
+
+      // Each 1 second, call incrementGenerationStep until generationStep is 4
+      const interval = setInterval(() => {
+        incrementGenerationStep();
+        if (generationStep === 4) {
+          clearInterval(interval);
+        }
+      }, 1000);
     }
   };
 

--- a/app/(dashboard)/generate/page.tsx
+++ b/app/(dashboard)/generate/page.tsx
@@ -78,14 +78,14 @@ export default function Generate() {
   const quizService = useQuizService();
   const { quizId, isGenerating, generateQuiz } = useQuiz(quizService);
 
+  // Summary sheet generation
+  const summarySheetsService = useSummarySheetService();
+  const { sheetId, generateSheet } = useSheet(summarySheetsService);
+
   // Course creation
   const courseService = useCourseService();
   const { courseId, isCreating, courseError, createCourse,
     addQuizToCourse,addSheetToCourse } = useCourse(courseService);
-
-  const summarySheetsService = useSummarySheetService();
-  const blobService = useBlobService();
-  const { sheetId, generateSheet } = useSheet(summarySheetsService, blobService);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files || []);

--- a/components/recognition/textRecognizer.tsx
+++ b/components/recognition/textRecognizer.tsx
@@ -25,7 +25,7 @@ const TextRecognizer = ({
           });
           onTextRecognized(result.data.text);
           console.log("Final text: ", result.data.text);
-        } catch (error) {
+        } catch (error: any) {
           console.error("Error recognizing text:", error);
           toast.error("Error recognizing text:", error);
         } finally {

--- a/components/recognition/textRecognizer.tsx
+++ b/components/recognition/textRecognizer.tsx
@@ -24,7 +24,8 @@ const TextRecognizer = ({
             logger: (m) => console.log(m),
           });
           onTextRecognized(result.data.text);
-        } catch (error: any) {
+          console.log("Final text: ", result.data.text);
+        } catch (error) {
           console.error("Error recognizing text:", error);
           toast.error("Error recognizing text:", error);
         } finally {

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./useQuiz";
 export * from "./useCourse";
+export * from "./useSheet";
 

--- a/hooks/useBlob.ts
+++ b/hooks/useBlob.ts
@@ -6,7 +6,6 @@ export function useBlob(blobService: BlobService) {
     const [error, setError] = useState<string | null>(null);
     const [fileId, setFileId] = useState("");
 
-
     async function uploadFile(file: File, fileType: string) {
         setIsUploading(true);
         setError(null);

--- a/hooks/useBlob.ts
+++ b/hooks/useBlob.ts
@@ -1,0 +1,28 @@
+import type { BlobService } from "@/services";
+import { useState } from "react";
+
+export function useBlob(blobService: BlobService) {
+    const [isUploading, setIsUploading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [fileId, setFileId] = useState("");
+
+
+    async function uploadFile(file: File, fileType: string) {
+        setIsUploading(true);
+        setError(null);
+
+        try {
+            const fileResponse = await blobService.uploadFile(file, fileType);
+            setFileId(fileResponse._id);
+        } catch (error) {
+            console.error("Error uploading file: ", error);
+            setError("Failed to upload file. Please try again.");
+          } finally {
+            setIsUploading(false);
+        }
+    }
+
+    return {
+        uploadFile
+    };
+}

--- a/hooks/useCourse.ts
+++ b/hooks/useCourse.ts
@@ -83,6 +83,19 @@ export function useCourse(courseService: CourseService) {
     }
   };
 
+  const addSheetToCourse = async (courseId: string, sheetId: string) => {
+    try {
+      await courseService.addSheetToCourse(courseId, sheetId);
+    } catch (error) {
+      console.error(
+        `Error adding summary sheet ${sheetId} to course ${courseId} `,
+        error
+      );
+      setError('Failed to associate summary sheet to course. Please try again.');
+      return null;
+    }
+  };
+
   const createExam = async (
     courseId: string,
     title: string,
@@ -172,6 +185,7 @@ export function useCourse(courseService: CourseService) {
     loadCourse,
     loadAllCourses,
     addQuizToCourse,
+    addSheetToCourse,
     createExam,
     getExams,
     updateExamById,

--- a/hooks/useSheet.ts
+++ b/hooks/useSheet.ts
@@ -1,0 +1,62 @@
+import type { SummarySheetService, BlobService } from "@/services";
+import { useState } from "react";
+import testData from "../json/testData/quizResponse.json";
+
+const tempData = testData; // Temporary test data for the quiz
+
+interface SummarySheet {
+  textString: string
+}
+
+export function useSheet(
+  summarySheetService: SummarySheetService,
+  blobService: BlobService,
+) {
+  const [sheetData, setSheetData] = useState<SummarySheet>();
+  const [sheetId, setSheetId] = useState("");
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const generateSheet = async (recognizedTexts: string[]) => {
+    setIsGenerating(true);
+    setError(null);
+
+    try {
+      const sheet = await summarySheetService.generateSheet(recognizedTexts);
+      const newSheetId = sheet.id;
+
+      setSheetId(newSheetId);
+
+      return { success: true, newSheetId };
+
+    } catch (error) {
+        console.error("Error generating summary sheet: ", error);
+        setError("Failed to generate summary sheet. Please try again.");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  // const loadSheet = async (sheetId: string) => {
+  //   try {
+  //     const sheetResponse = await blobService.getFileById(sheetId);
+  //     setSheetData(sheetResponse.item);
+
+  //     return sheetResponse.item;
+
+  //   } catch (error) {
+  //       console.error(`Error getting summary sheet file ${sheetId} `, error);
+  //       setError("Failed to load summary sheet file. Please try again.");
+  //     return null;
+  //   }
+  // };
+
+
+  return {
+    sheetId,
+    error,
+    sheetData,
+    generateSheet
+    // loadSheet,
+  };
+}

--- a/hooks/useSheet.ts
+++ b/hooks/useSheet.ts
@@ -9,8 +9,7 @@ interface SummarySheet {
 }
 
 export function useSheet(
-  summarySheetService: SummarySheetService,
-  blobService: BlobService,
+  summarySheetService: SummarySheetService
 ) {
   const [sheetData, setSheetData] = useState<SummarySheet>();
   const [sheetId, setSheetId] = useState("");
@@ -37,26 +36,10 @@ export function useSheet(
     }
   }
 
-  // const loadSheet = async (sheetId: string) => {
-  //   try {
-  //     const sheetResponse = await blobService.getFileById(sheetId);
-  //     setSheetData(sheetResponse.item);
-
-  //     return sheetResponse.item;
-
-  //   } catch (error) {
-  //       console.error(`Error getting summary sheet file ${sheetId} `, error);
-  //       setError("Failed to load summary sheet file. Please try again.");
-  //     return null;
-  //   }
-  // };
-
-
   return {
     sheetId,
     error,
     sheetData,
     generateSheet
-    // loadSheet,
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.4",
         "@tanstack/react-table": "^8.20.6",
@@ -1544,6 +1545,179 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.5.tgz",
+      "integrity": "sha512-5ijLkak6ZMylXsaImpZ8u4Rlf5grRmoc0p0QeX9VJtlrM4f5m3nCTX8tWga/zOA8PZYIR/t0p2Mnvd7InrJ6yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-toast": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.6.tgz",
@@ -1631,6 +1805,39 @@
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.0"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/services/ai/summarySheet.ts
+++ b/services/ai/summarySheet.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 export interface SummarySheetService {
     generateSheet: (recognizedText: string[]) => Promise<any>;
-    // getSheetById: (sheetId: string) => Promise<any>;
+    getSheetById: (sheetId: string) => Promise<any>;
 }
 
 export function useSummarySheetService(): SummarySheetService {
@@ -22,16 +22,16 @@ export function useSummarySheetService(): SummarySheetService {
     }
   };
 
-  // const getSheetById = async (sheetId: string) => {
-  //   try {
-  //     const response = await axios.get(`${apiUrl}/blob/${sheetId}`, {
-  //       withCredentials: true,
-  //     });
-  //     return response.data;
-  //   } catch (error) {
-  //     console.error(`An error ocurred getting the summary sheet ${sheetId}`, error);
-  //   }
-  // };
+  const getSheetById = async (sheetId: string) => {
+    try {
+      const response = await axios.get(`${apiUrl}/summary-sheets/${sheetId}`, {
+        withCredentials: true,
+      });
+      return response.data;
+    } catch (error) {
+      console.error(`An error ocurred getting the summary sheet ${sheetId}`, error);
+    }
+  };
 
-  return { generateSheet };
+  return { generateSheet, getSheetById };
 }

--- a/services/ai/summarySheet.ts
+++ b/services/ai/summarySheet.ts
@@ -1,0 +1,37 @@
+import axios from "axios";
+
+export interface SummarySheetService {
+    generateSheet: (recognizedText: string[]) => Promise<any>;
+    // getSheetById: (sheetId: string) => Promise<any>;
+}
+
+export function useSummarySheetService(): SummarySheetService {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  const generateSheet = async (recognizedText: string[]) => {
+    try {
+      const textString = recognizedText.join("\n");
+
+      const response = await axios.post(`${apiUrl}/ai/generate-sheet`, {
+        textString,
+      });
+
+      return response.data;
+    } catch (error) {
+      console.error("An error ocurred generating the summary sheet", error);
+    }
+  };
+
+  // const getSheetById = async (sheetId: string) => {
+  //   try {
+  //     const response = await axios.get(`${apiUrl}/blob/${sheetId}`, {
+  //       withCredentials: true,
+  //     });
+  //     return response.data;
+  //   } catch (error) {
+  //     console.error(`An error ocurred getting the summary sheet ${sheetId}`, error);
+  //   }
+  // };
+
+  return { generateSheet };
+}

--- a/services/blob.ts
+++ b/services/blob.ts
@@ -1,0 +1,42 @@
+import axios from "axios";
+
+export interface BlobService {
+  uploadFile: (file: File, fileType: string) => Promise<any>;
+  getFileById: (fileId: string) => Promise<any>;
+}
+
+export function useBlobService() {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  const uploadFile = async (file: File, fileType: string) => {
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('fileType', fileType);
+
+      const response = await axios.post(`${apiUrl}/blob/files`, formData, {
+        withCredentials: true,
+        headers: {
+          'Content-Type': 'multipart/form-data'
+        }
+      });
+
+      return response.data;
+    } catch (error) {
+      console.error("An error ocurred uploading the file", error);
+    }
+  };
+
+  const getFileById = async (fileId: string) => {
+    try {
+      const response = await axios.get(`${apiUrl}/blob/files/${fileId}`, {
+        withCredentials: true,
+      });
+      return response.data;
+    } catch (error) {
+        console.error(`An error ocurred fetching the file`, error);
+    }
+  };
+
+  return { uploadFile, getFileById };
+}

--- a/services/course.ts
+++ b/services/course.ts
@@ -4,6 +4,7 @@ export interface CourseService {
   createCourse: (title: string, subject: string, level: string) => Promise<any>;
   getCourseById: (courseId: string) => Promise<any>;
   addQuizToCourse: (courseId: string, quizId: string) => Promise<any>;
+  addSheetToCourse: (courseId: string, sheetId: string) => Promise<any>;
   createExam: (
     courseId: string,
     title: string,
@@ -82,6 +83,22 @@ export function useCourseService() {
     }
   };
 
+  const addSheetToCourse = async (courseId: string, sheetId: string) => {
+    try {
+      const response = await axios.post(
+        `${apiUrl}/courses/${courseId}/addSheet`,
+        { sheetId: sheetId },
+        { withCredentials: true }
+      );
+      return response.data;
+    } catch (error) {
+      console.error(
+        `An error ocurred adding the summary sheet ${sheetId} to the course ${courseId}`,
+        error
+      );
+    }
+  };
+
   // Course's Exams \\
   const createExam = async (
     courseId: string,
@@ -155,6 +172,7 @@ export function useCourseService() {
     createCourse,
     getCourseById,
     addQuizToCourse,
+    addSheetToCourse,
     createExam,
     getExamById,
     updateExamById,

--- a/services/index.ts
+++ b/services/index.ts
@@ -1,3 +1,5 @@
 export * from "./ai/quiz";
+export * from "./ai/summarySheet";
 export * from "./course";
 export * from "./insights";
+export * from "./blob";


### PR DESCRIPTION
**Changes**

- Add **summary sheet** service to handle everything related to the summary sheets
-  A summary sheet is now **generated** alongside the quiz during course creation (generation page). The sheet is automatically associated to the course. 
- Add blob-related code (functions, service..etc) that we will use soon