### PR TITLE
feat: add middleware for JWT-based auth redirections

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
-import { NextRequest } from 'next/server'
+import { NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { jwtDecode } from "jwt-decode";
 
 interface JwtToken {
@@ -11,16 +11,16 @@ interface JwtToken {
 
 export function middleware(req: NextRequest) {
     const { pathname } = req.nextUrl;
-    const cookie  = req.cookies.get('auth_token');
+    const cookie = req.cookies.get("auth_token");
 
     let decodedToken: JwtToken | undefined;
     let userRole: string | undefined;
 
-    const adminRoutes = ['/admin'];
+    const adminRoutes = ["/admin"];
 
     if (!cookie) {
         console.log("There's no cookie ! Redirecting to /auth");
-        return NextResponse.redirect(new URL("/auth", req.url))
+        return NextResponse.redirect(new URL("/auth", req.url));
     }
 
     if (cookie) {
@@ -38,9 +38,9 @@ export function middleware(req: NextRequest) {
     }
 
     if (adminRoutes.some(route => pathname.startsWith(route))) {
-        if (userRole != 'admin') {
+        if (userRole != "admin") {
             console.log("Redirecting to unauthorized");
-            return NextResponse.redirect(new URL('/unauthorized', req.url))
+            return NextResponse.redirect(new URL("/unauthorized", req.url));
         }
     }
 
@@ -48,7 +48,8 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-    matcher: [                                      //      Match all routes except
-        '/((?!api|static|.*\\..*|_next|auth).*)',   //      /api, /static, file extensions, /_next, and /auth
-    ]
+    matcher: [
+        //      Match all routes except
+        "/((?!api|static|.*\\..*|_next|auth).*)", //      /api, /static, file extensions, /_next, and /auth
+    ],
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,25 +1,54 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import { NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
+import { jwtDecode } from "jwt-decode";
 
-// Since we're using client-side authentication with localStorage,
-// we'll let the client-side AuthGuard components handle route protection
-// This middleware only handles static file serving and basic routing
-export function middleware(request: NextRequest) {
-    const { pathname } = request.nextUrl;
+interface JwtToken {
+    userId: string;
+    iat: number;
+    exp: number;
+    role?: string;
+}
 
-    // Allow all paths - client-side auth guards will handle protection
+export function middleware(req: NextRequest) {
+    const { pathname } = req.nextUrl;
+    const cookie  = req.cookies.get('auth_token');
+
+    let decodedToken: JwtToken | undefined;
+    let userRole: string | undefined;
+
+    const adminRoutes = ['/admin'];
+
+    if (!cookie) {
+        console.log("There's no cookie ! Redirecting to /auth");
+        return NextResponse.redirect(new URL("/auth", req.url))
+    }
+
+    if (cookie) {
+        try {
+            decodedToken = jwtDecode<JwtToken>(cookie.value);
+            const isTokenExpired = Date.now() >= decodedToken.exp * 1000;
+
+            if (isTokenExpired) {
+                console.log("Token expired, redirecting...");
+                return NextResponse.redirect(new URL("/auth", req.url));
+            }
+        } catch (error) {
+            return NextResponse.redirect(new URL("/auth", req.url));
+        }
+    }
+
+    if (adminRoutes.some(route => pathname.startsWith(route))) {
+        if (userRole != 'admin') {
+            console.log("Redirecting to unauthorized");
+            return NextResponse.redirect(new URL('/unauthorized', req.url))
+        }
+    }
+
     return NextResponse.next();
 }
 
 export const config = {
-    matcher: [
-        /*
-         * Match all request paths except:
-         * - _next/static (static files)
-         * - _next/image (image optimization files)
-         * - favicon.ico (favicon file)
-         * - public folder
-         */
-        "/((?!_next/static|_next/image|favicon.ico|public/).*)",
-    ],
+    matcher: [                                      //      Match all routes except
+        '/((?!api|static|.*\\..*|_next|auth).*)',   //      /api, /static, file extensions, /_next, and /auth
+    ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
         "": {
             "name": "my-app",
             "version": "0.1.0",
-            "hasInstallScript": true,
             "dependencies": {
                 "@hookform/resolvers": "^3.9.1",
                 "@radix-ui/react-avatar": "^1.1.1",
@@ -34,6 +33,7 @@
                 "dotenv": "^16.4.5",
                 "html2pdf.js": "^0.10.3",
                 "jszip": "^3.10.1",
+                "jwt-decode": "^4.0.0",
                 "lucide-react": "^0.460.0",
                 "marked": "^15.0.12",
                 "next": "14.2.16",
@@ -5759,6 +5759,15 @@
                 "pako": "~1.0.2",
                 "readable-stream": "~2.3.6",
                 "setimmediate": "^1.0.5"
+            }
+        },
+        "node_modules/jwt-decode": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+            "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "dotenv": "^16.4.5",
         "html2pdf.js": "^0.10.3",
         "jszip": "^3.10.1",
+        "jwt-decode": "^4.0.0",
         "lucide-react": "^0.460.0",
         "marked": "^15.0.12",
         "next": "14.2.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
+      jwt-decode:
+        specifier: ^4.0.0
+        version: 4.0.0
       lucide-react:
         specifier: ^0.460.0
         version: 0.460.0(react@18.3.1)
@@ -2276,6 +2279,10 @@ packages:
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -5311,6 +5318,8 @@ snapshots:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+
+  jwt-decode@4.0.0: {}
 
   keyv@4.5.4:
     dependencies:


### PR DESCRIPTION
**Changes**

- Implemented the frontend **middleware** that ensures the user is **redirected** to `/auth`if the JWT token is expired or if there’s no cookie, enhancing the user experience. This is in addition to the **server-side** data fetching already handled with JWT.

- Prepared **role-based** access control handling (e.g., for future `/admin` routes), according to the backend, even though the `/admin` routes aren't implemented **yet**.

Closes #59 