### PR TITLE
feat(generate): add file upload handling before course generation

### DIFF
--- a/app/(dashboard)/generate/page.tsx
+++ b/app/(dashboard)/generate/page.tsx
@@ -68,7 +68,13 @@ export default function Generate() {
 
             setCourseId(courseResponse.id);
 
-            // 2. Start generation with SSE tracking - send extracted text, NOT raw files
+            const fileIds = Object.values(uploadedFileIds);
+            await Promise.all(
+                fileIds.map(fileId =>
+                    courseService.addFileToCourse(courseResponse.id, fileId)
+                )
+            );
+
             const generationResponse =
                 await courseService.startCourseGeneration(courseResponse.id, {
                     extractedTexts: recognizedTexts,


### PR DESCRIPTION
## Summary

Add file-to-course association step during the generation flow. Before starting course generation, uploaded files are now explicitly linked to the course via `addFileToCourse` API calls.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance
- [ ] Other

## Changes Overview

### Generation Flow
- Added file association step between course creation and generation start
- All uploaded files are now linked to the course via `courseService.addFileToCourse()` before generation begins
- File associations are performed in parallel using `Promise.all`

## Technical Details

**Files Changed:** 1 file
**Main Areas:**
- `app/(dashboard)/generate/page.tsx`: Added file upload handling logic

## Related PRs

> **This PR must be merged simultaneously with the backend PR:**
> [fix(course): return 200 with empty array for courses with no files - EdukaiFR/backend#95](https://github.com/EdukaiFR/backend/pull/95)
>
> Both PRs work together: the backend handles the file route fix, and this frontend PR sends file associations before generation.

## Testing

- [ ] Tested locally
- [ ] No regression in existing features

## Breaking Changes

None

## Deployment Notes

Must be deployed alongside [EdukaiFR/backend#95](https://github.com/EdukaiFR/backend/pull/95).