### PR TITLE
feat(library): add course deletion with confirmation dialog

### DIFF
--- a/app/(dashboard)/library/page.tsx
+++ b/app/(dashboard)/library/page.tsx
@@ -17,7 +17,7 @@ import { useCourse } from "@/hooks";
 import { useSessionStorage } from "@/hooks/useSessionStorage";
 import { useCourseService } from "@/services";
 import { RotateCcw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { VisibilityType } from "@/lib/types/visibility";
 
@@ -63,10 +63,18 @@ type ApiCourseData = {
 export default function LibraryPage() {
     // Basic Data
     const courseService = useCourseService();
-    const { coursesData, loadAllCourses } = useCourse(courseService);
+    const { coursesData, loadAllCourses, deleteCourse } = useCourse(courseService);
     const [userCourses, setUserCourses] = useState<ExtendedCourseData[]>([]);
 
     const { storageUserId } = useSessionStorage();
+
+    const handleDeleteCourse = useCallback(async (courseId: string): Promise<boolean> => {
+        const success = await deleteCourse(courseId);
+        if (success) {
+            setUserCourses(prev => prev.filter(c => c.id !== courseId));
+        }
+        return success;
+    }, [deleteCourse]);
 
     // View State - Load from localStorage or default to 'grid'
     const [view, setView] = useState<"grid" | "table">(() => {
@@ -364,8 +372,12 @@ export default function LibraryPage() {
                                     createdAt: course.createdAt,
                                     isPublished: course.isPublished,
                                     visibility: course.visibility,
+                                    quizzesCount: course.quizzes?.length ?? 0,
+                                    examsCount: course.exams?.length ?? 0,
+                                    summarySheetsCount: course.summarySheets?.length ?? 0,
                                 }))}
                                 isLoading={false}
+                                onDeleteCourse={handleDeleteCourse}
                             />
                         ) : (
                             <DataTable

--- a/components/library/CourseCard.tsx
+++ b/components/library/CourseCard.tsx
@@ -3,20 +3,35 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
 import { formatDate } from "@/lib/date-format";
 import type { VisibilityType } from "@/lib/types/visibility";
 import { Visibility } from "@/lib/types/visibility";
 import {
+    AlertTriangle,
     BookOpen,
     Calendar,
     Eye,
+    FileText,
     GraduationCap,
+    ClipboardList,
     User,
     Globe,
     Lock,
+    Loader2,
+    Trash2,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useState, useCallback } from "react";
 
 export type CourseCardProps = {
     id: string;
@@ -27,6 +42,10 @@ export type CourseCardProps = {
     createdAt: string;
     isPublished: boolean;
     visibility?: VisibilityType;
+    quizzesCount?: number;
+    examsCount?: number;
+    summarySheetsCount?: number;
+    onDelete?: (courseId: string) => Promise<boolean>;
 };
 
 export const CourseCard = ({
@@ -38,8 +57,24 @@ export const CourseCard = ({
     createdAt,
     isPublished = true,
     visibility = Visibility.PRIVATE,
+    quizzesCount = 0,
+    examsCount = 0,
+    summarySheetsCount = 0,
+    onDelete,
 }: CourseCardProps) => {
     const router = useRouter();
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
+
+    const handleDelete = useCallback(async () => {
+        if (!onDelete) return;
+        setIsDeleting(true);
+        const success = await onDelete(id);
+        setIsDeleting(false);
+        if (success) {
+            setIsDeleteDialogOpen(false);
+        }
+    }, [onDelete, id]);
 
     const getSubjectColor = (subject: string) => {
         const colors = {
@@ -98,15 +133,27 @@ export const CourseCard = ({
                                 {title}
                             </h3>
                         </div>
-                        <Link href={`/library/${id}`}>
-                            <Button
-                                variant="ghost"
-                                size="sm"
-                                className="opacity-0 group-hover:opacity-100 transition-all duration-300 ml-4 hover:bg-blue-50 hover:text-blue-600 transform translate-x-2 group-hover:translate-x-0 flex-shrink-0"
-                            >
-                                <Eye className="w-4 h-4" />
-                            </Button>
-                        </Link>
+                        <div className="flex items-center gap-1 ml-4 flex-shrink-0">
+                            <Link href={`/library/${id}`}>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="opacity-0 group-hover:opacity-100 transition-all duration-300 hover:bg-blue-50 hover:text-blue-600 transform translate-x-2 group-hover:translate-x-0"
+                                >
+                                    <Eye className="w-4 h-4" />
+                                </Button>
+                            </Link>
+                            {onDelete && (
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="opacity-0 group-hover:opacity-100 transition-all duration-300 hover:bg-red-50 hover:text-red-600 transform translate-x-2 group-hover:translate-x-0"
+                                    onClick={() => setIsDeleteDialogOpen(true)}
+                                >
+                                    <Trash2 className="w-4 h-4" />
+                                </Button>
+                            )}
+                        </div>
                     </div>
 
                     {/* Content Section */}
@@ -183,6 +230,83 @@ export const CourseCard = ({
                     </div>
                 </div>
             </CardContent>
+
+            {/* Delete Confirmation Dialog */}
+            <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+                <DialogContent className="sm:max-w-[480px]">
+                    <DialogHeader>
+                        <DialogTitle className="flex items-center gap-2 text-red-600">
+                            <AlertTriangle className="w-5 h-5" />
+                            Supprimer le cours
+                        </DialogTitle>
+                        <DialogDescription>
+                            Cette action est irréversible. Le cours et toutes les
+                            données associées seront définitivement supprimés.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="space-y-3 py-2">
+                        <p className="text-sm font-medium text-gray-900">
+                            Vous allez supprimer le cours :
+                        </p>
+                        <div className="p-3 bg-gray-50 rounded-lg border border-gray-200">
+                            <p className="font-semibold text-gray-900">{title}</p>
+                            <p className="text-sm text-gray-500 mt-1">
+                                {subject} - {level}
+                            </p>
+                        </div>
+
+                        {(quizzesCount > 0 || examsCount > 0 || summarySheetsCount > 0) && (
+                            <div className="p-3 bg-red-50 rounded-lg border border-red-200">
+                                <p className="text-sm font-medium text-red-800 mb-2">
+                                    Les éléments suivants seront également supprimés :
+                                </p>
+                                <ul className="space-y-1.5">
+                                    {quizzesCount > 0 && (
+                                        <li className="flex items-center gap-2 text-sm text-red-700">
+                                            <ClipboardList className="w-4 h-4 flex-shrink-0" />
+                                            {quizzesCount} quiz{quizzesCount > 1 ? "zes" : ""}
+                                        </li>
+                                    )}
+                                    {examsCount > 0 && (
+                                        <li className="flex items-center gap-2 text-sm text-red-700">
+                                            <GraduationCap className="w-4 h-4 flex-shrink-0" />
+                                            {examsCount} examen{examsCount > 1 ? "s" : ""}
+                                        </li>
+                                    )}
+                                    {summarySheetsCount > 0 && (
+                                        <li className="flex items-center gap-2 text-sm text-red-700">
+                                            <FileText className="w-4 h-4 flex-shrink-0" />
+                                            {summarySheetsCount} fiche{summarySheetsCount > 1 ? "s" : ""} de révision
+                                        </li>
+                                    )}
+                                </ul>
+                            </div>
+                        )}
+                    </div>
+
+                    <DialogFooter className="gap-2 sm:gap-0">
+                        <DialogClose asChild>
+                            <Button variant="outline" disabled={isDeleting}>
+                                Annuler
+                            </Button>
+                        </DialogClose>
+                        <Button
+                            variant="destructive"
+                            onClick={handleDelete}
+                            disabled={isDeleting}
+                            className="gap-2"
+                        >
+                            {isDeleting ? (
+                                <Loader2 className="w-4 h-4 animate-spin" />
+                            ) : (
+                                <Trash2 className="w-4 h-4" />
+                            )}
+                            {isDeleting ? "Suppression..." : "Supprimer"}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </Card>
     );
 };

--- a/components/library/CourseGrid.tsx
+++ b/components/library/CourseGrid.tsx
@@ -6,9 +6,10 @@ import { CourseCard, CourseCardProps } from "./CourseCard";
 interface CourseGridProps {
     courses: CourseCardProps[];
     isLoading?: boolean;
+    onDeleteCourse?: (courseId: string) => Promise<boolean>;
 }
 
-export const CourseGrid = ({ courses, isLoading = false }: CourseGridProps) => {
+export const CourseGrid = ({ courses, isLoading = false, onDeleteCourse }: CourseGridProps) => {
     if (isLoading) {
         return (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -58,7 +59,7 @@ export const CourseGrid = ({ courses, isLoading = false }: CourseGridProps) => {
                         animationFillMode: "both",
                     }}
                 >
-                    <CourseCard {...course} />
+                    <CourseCard {...course} onDelete={onDeleteCourse} />
                 </div>
             ))}
         </div>

--- a/hooks/useCourse.ts
+++ b/hooks/useCourse.ts
@@ -238,6 +238,24 @@ export function useCourse(courseService: CourseService) {
         }
     };
 
+    const deleteCourse = async (courseId: string): Promise<boolean> => {
+        try {
+            const response = await courseService.deleteCourse(courseId);
+            if ("status" in response && response.status === "failure") {
+                courseToast.deleteError();
+                return false;
+            }
+            setCoursesData(prev => prev.filter(c => c._id !== courseId));
+            courseToast.deleteSuccess();
+            return true;
+        } catch (error) {
+            console.error(`Error deleting course ${courseId}:`, error);
+            courseToast.deleteError();
+            setError("Failed to delete course. Please try again.");
+            return false;
+        }
+    };
+
     const deleteExamById = async (examId: string, courseId: string) => {
         try {
             const response = await courseService.deleteExamById(
@@ -271,5 +289,6 @@ export function useCourse(courseService: CourseService) {
         getExams,
         updateExamById,
         deleteExamById,
+        deleteCourse,
     };
 }

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -380,6 +380,8 @@ export const courseToast = {
     loadError: () => showToast.error(toastMessages.course.loadError),
     updateSuccess: () => showToast.success(toastMessages.course.updateSuccess),
     updateError: () => showToast.error(toastMessages.course.updateError),
+    deleteSuccess: () => showToast.success(toastMessages.course.deleteSuccess),
+    deleteError: () => showToast.error(toastMessages.course.deleteError),
 };
 
 export const examToast = {

--- a/services/course.ts
+++ b/services/course.ts
@@ -184,6 +184,9 @@ export interface CourseService {
         message: string;
         status: string;
     } | null>;
+    deleteCourse: (
+        courseId: string
+    ) => Promise<{ status: string; message: string } | ApiErrorResponse>;
     updateVisibility: (
         courseId: string,
         visibility: Visibility
@@ -394,6 +397,27 @@ export function useCourseService() {
         }
     };
 
+    const deleteCourse = async (
+        courseId: string
+    ): Promise<{ status: string; message: string } | ApiErrorResponse> => {
+        try {
+            const response = await axios.delete(
+                `${apiUrl}/courses/${courseId}`,
+                { withCredentials: true }
+            );
+            return response.data;
+        } catch (error: unknown) {
+            const err = error as ApiError;
+            if (err?.response?.data) {
+                return err.response.data as ApiErrorResponse;
+            }
+            return {
+                status: "failure",
+                message: "Une erreur est survenue lors de la suppression du cours.",
+            };
+        }
+    };
+
     const updateVisibility = async (
         courseId: string,
         visibility: Visibility
@@ -520,6 +544,7 @@ export function useCourseService() {
         getExamById,
         updateExamById,
         deleteExamById,
+        deleteCourse,
         getAllExams,
         updateVisibility,
         getPublicCourses,


### PR DESCRIPTION
## Summary

Add the ability for users to delete courses from their library. Includes a confirmation dialog that shows associated content (quizzes, exams, summary sheets) that will also be deleted, along with file upload handling before course generation.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance
- [ ] Other

## Changes Overview

### Course Deletion
- Add `deleteCourse` method to `CourseService` (API call via axios)
- Add `deleteCourse` function in `useCourse` hook with toast notifications
- Add delete button (trash icon) on `CourseCard` with hover reveal
- Add confirmation dialog showing course details and associated content counts (quizzes, exams, summary sheets)
- Wire up deletion flow from `LibraryPage` through `CourseGrid` to `CourseCard`
- Add `deleteSuccess` / `deleteError` toast messages

### File Upload Handling
- Link uploaded files to courses via `addFileToCourse` before starting generation

## Technical Details

**Files Changed:** 7 files
**Main Areas:**
- `services/course.ts`: New `deleteCourse` API method
- `hooks/useCourse.ts`: New `deleteCourse` hook function with state management
- `components/library/CourseCard.tsx`: Delete button + confirmation dialog UI
- `components/library/CourseGrid.tsx`: Pass `onDeleteCourse` prop through grid
- `app/(dashboard)/library/page.tsx`: Wire deletion handler, pass content counts
- `app/(dashboard)/generate/page.tsx`: Add file-to-course linking before generation
- `lib/toast.ts`: Add delete success/error toast messages

## Testing

- [ ] Tested locally
- [ ] No regression in existing features

## Breaking Changes

None

## Deployment Notes

No special steps required.

Closes #96