### PR TITLE
feat(auth): add client-side refresh token interceptor

### DIFF
--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/lib/setup-interceptor";
 import React, {
     createContext,
     useContext,

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -31,11 +31,8 @@ export function useSession() {
             // Validate token and get user data
             validateSession();
         } else if (token && storedUser) {
-            // Check if token is expired
             if (isTokenExpired(token)) {
-                sessionStorage.clearSession();
-                setUser(null);
-                setLoading(false);
+                validateSession();
             } else {
                 setLoading(false);
             }
@@ -51,12 +48,7 @@ export function useSession() {
 
     const validateSession = async () => {
         try {
-            const response = await authService.refreshToken();
-            sessionStorage.setToken(response.token);
-
-            // Get current user ID to fetch fresh profile
             const currentUser = sessionStorage.getUser();
-            // Handle both id formats
             const userId = currentUser?.id || currentUser?._id;
 
             if (userId) {
@@ -67,7 +59,6 @@ export function useSession() {
 
             setLoading(false);
         } catch {
-            // If refresh fails, clear session and continue
             sessionStorage.clearSession();
             setUser(null);
             setLoading(false);

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -57,24 +57,6 @@ export function getAuthConfig() {
 }
 
 /**
- * Synchronize the auth token from localStorage to a cookie
- * This is needed for the backend to receive the token in requests that require cookies
- */
-export function syncAuthCookie() {
-    if (typeof window === "undefined") return;
-
-    const token = sessionStorage.getToken();
-    if (token) {
-        // Set cookie with appropriate flags
-        // Note: In development (localhost), Secure might need to be false if not using HTTPS
-        // SameSite=Lax is usually good for top-level navigations, but for API calls
-        // across ports/domains, we might need to be careful.
-        // For now, we set it simply to ensure it's available.
-        document.cookie = `auth_token=${token}; path=/; max-age=86400; SameSite=Lax`;
-    }
-}
-
-/**
  * Check if a JWT token is expired
  * @param token JWT token string
  * @returns true if expired or invalid, false otherwise

--- a/lib/constants/auth.ts
+++ b/lib/constants/auth.ts
@@ -1,0 +1,8 @@
+export const AUTH_ENDPOINTS = [
+    "/auth/login",
+    "/auth/register",
+    "/auth/refresh",
+    "/auth/forgot-password",
+    "/auth/reset-password",
+    "/auth/verify-reset-token",
+] as const;

--- a/lib/setup-interceptor.ts
+++ b/lib/setup-interceptor.ts
@@ -1,0 +1,83 @@
+import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
+import { AUTH_ENDPOINTS } from "@/lib/constants/auth";
+import { sessionStorage } from "@/lib/session";
+
+interface QueueItem {
+    resolve: (value: unknown) => void;
+    reject: (reason: unknown) => void;
+    config: InternalAxiosRequestConfig;
+}
+
+let isRefreshing = false;
+let failedQueue: QueueItem[] = [];
+
+/**
+ * @param error Error to resolve or reject for each queued request
+ */
+function processQueue(error: AxiosError | null): void {
+    failedQueue.forEach((item) => {
+        if (error) {
+            item.reject(error);
+        } else {
+            item.resolve(axios(item.config));
+        }
+    });
+    failedQueue = [];
+}
+
+/**
+ * @param url Request URL to check
+ * @returns Whether the URL is an auth endpoint that should skip 401 interception
+ */
+function isAuthEndpoint(url: string | undefined): boolean {
+    if (!url) return false;
+    return AUTH_ENDPOINTS.some((endpoint) => url.includes(endpoint));
+}
+
+axios.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+        const originalRequest = error.config as InternalAxiosRequestConfig & {
+            _retry?: boolean;
+        };
+
+        if (
+            error.response?.status !== 401 ||
+            !originalRequest ||
+            originalRequest._retry ||
+            isAuthEndpoint(originalRequest.url)
+        ) {
+            return Promise.reject(error);
+        }
+
+        if (isRefreshing) {
+            return new Promise((resolve, reject) => {
+                failedQueue.push({ resolve, reject, config: originalRequest });
+            });
+        }
+
+        originalRequest._retry = true;
+        isRefreshing = true;
+
+        try {
+            const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+            const response = await axios.post(
+                `${apiUrl}/auth/refresh`,
+                {},
+                { withCredentials: true }
+            );
+            sessionStorage.setToken(response.data.token);
+            processQueue(null);
+            return axios(originalRequest);
+        } catch (refreshError) {
+            processQueue(refreshError as AxiosError);
+            sessionStorage.clearSession();
+            if (typeof window !== "undefined") {
+                window.location.href = "/auth";
+            }
+            return Promise.reject(refreshError);
+        } finally {
+            isRefreshing = false;
+        }
+    }
+);

--- a/middleware.ts
+++ b/middleware.ts
@@ -28,12 +28,12 @@ export function middleware(req: NextRequest) {
             const isTokenExpired = Date.now() >= decodedToken.exp * 1000;
 
             if (isTokenExpired) {
-                return NextResponse.redirect(new URL("/auth", req.url));
+                return NextResponse.next();
             }
 
             userRole = decodedToken.role;
-        } catch (error) {
-            return NextResponse.redirect(new URL("/auth", req.url));
+        } catch {
+            return NextResponse.next();
         }
     }
 

--- a/services/payment.ts
+++ b/services/payment.ts
@@ -1,4 +1,3 @@
-import { syncAuthCookie } from "@/lib/auth-utils";
 import { ApiError } from "@/lib/types/api";
 import axios from "axios";
 
@@ -122,8 +121,6 @@ export function usePaymentService(): PaymentService {
     const createCheckoutSession =
         async (): Promise<CheckoutSessionResponse> => {
             try {
-                syncAuthCookie();
-
                 const response = await axios.post(
                     `${apiUrl}/payment/checkout`,
                     {},
@@ -141,8 +138,6 @@ export function usePaymentService(): PaymentService {
 
     const createPortalSession = async (): Promise<PortalSessionResponse> => {
         try {
-            syncAuthCookie();
-
             const response = await axios.post(
                 `${apiUrl}/payment/portal`,
                 {},

--- a/tests/unit/services/payment.test.ts
+++ b/tests/unit/services/payment.test.ts
@@ -19,11 +19,6 @@ vi.mock("axios", () => ({
     },
 }));
 
-// Mock auth-utils
-vi.mock("@/lib/auth-utils", () => ({
-    syncAuthCookie: vi.fn(),
-}));
-
 // Get mocked post function
 const mockedPost = axios.post as Mock;
 


### PR DESCRIPTION
## Summary

Adds transparent access token refresh on the frontend to complement the backend refresh token system. When any API call returns 401 due to an expired access token, a global axios interceptor automatically refreshes the token and retries the request without user intervention. Users stay logged in for up to 7 days.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [x] Refactoring
- [ ] Documentation
- [ ] Performance
- [ ] Other

## Changes Overview

### Axios 401 Interceptor
- New `lib/setup-interceptor.ts`: Global axios response interceptor that catches 401 errors, calls `POST /api/auth/refresh`, and retries the original request
- Queues concurrent requests during refresh to avoid duplicate refresh calls
- Skips interception on auth endpoints (login, register, refresh) to prevent loops
- Hard-redirects to `/auth` on refresh failure

### Middleware Update
- Expired tokens now pass through Next.js middleware instead of redirecting to `/auth`
- Client-side interceptor handles the refresh; middleware only redirects when cookie is completely missing

### Session Hook Update
- `useSession` delegates token refresh to the interceptor instead of calling `refreshToken()` directly
- Eliminates duplicate refresh calls that were happening on mount

### Cleanup
- Removed `syncAuthCookie()` from `lib/auth-utils.ts` (backend now sets HttpOnly cookies directly)
- Removed `syncAuthCookie` calls from payment service
- Removed corresponding test mock

## Technical Details

**Files Changed:** 8 files (+96/-41)
**Main Areas:**
- `lib/setup-interceptor.ts`: Core interceptor with refresh queue pattern
- `lib/constants/auth.ts`: Auth endpoint constants
- `middleware.ts`: Relaxed expired token handling
- `hooks/useSession.ts`: Simplified session validation
- `services/payment.ts`, `lib/auth-utils.ts`: Removed obsolete cookie sync

## Testing

- [x] All 73 tests passing
- [x] Build compiles cleanly
- [x] Tested locally with backend refresh token flow
- [x] No regression in existing features

## Breaking Changes

None. All changes are backward-compatible.

## Deployment Notes

- Must be deployed alongside or after the backend refresh token PR (EdukaiFR/backend#101)
- No environment variable changes required